### PR TITLE
fix(docs): ensure audio script typing compatibility

### DIFF
--- a/Build_docs/generate_audio_recent.py
+++ b/Build_docs/generate_audio_recent.py
@@ -17,6 +17,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 import re
+from typing import Optional
 
 
 def find_audio_files(docs_dir: Path):
@@ -62,7 +63,7 @@ def human_size(nbytes: int) -> str:
     return f"{nbytes / (1024*1024):.1f} MB"
 
 
-def audio_name_to_bib_doc(docs_dir: Path, wav_name: str) -> tuple[str | None, str | None]:
+def audio_name_to_bib_doc(docs_dir: Path, wav_name: str) -> tuple[Optional[str], Optional[str]]:
     """
     Attempt to map a WAV basename to a bib entry document (without extension).
 


### PR DESCRIPTION
## Summary
- import Optional for typing helpers in the audio generation script
- use Python 3.9-compatible tuple annotation for audio_name_to_bib_doc

## Testing
- python3 Build_docs/generate_audio_recent.py

------
https://chatgpt.com/codex/tasks/task_e_68dee896965c832791b0cdce2363cccb