### PR TITLE
ci: grant gh-pages push permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy-book:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
## Summary
- allow the deploy workflow to write to the repository by granting contents: write permissions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df22309798832780c4afebab8218fb